### PR TITLE
Removed leading slash for the kubectl command in exec.

### DIFF
--- a/drainmanager/kubernetes.go
+++ b/drainmanager/kubernetes.go
@@ -75,7 +75,7 @@ func (m *DrainManagerKubernetes) exec(args ...string) bool {
 		args = append(args, "--dry-run")
 	}
 
-	return m.runComand(exec.Command("/kubectl", args...))
+	return m.runComand(exec.Command("kubectl", args...))
 }
 
 func (m *DrainManagerKubernetes) runComand(cmd *exec.Cmd) bool {


### PR DESCRIPTION
Resolving error in Kubernetes deployment version.

{"level":"error","msg":"fork/exec /kubectl: no such file or directory","command":"kubectl"} 2024-09-25T15:53:42.984930129Z {"level":"info","caller":"manager/manager.go:277","msg":"drained failed","eventID":"267C5600-FEE5-406C-A8B8-58833494F238"}